### PR TITLE
Fix condition checking if a queue has the desired capabilities

### DIFF
--- a/Library/Source Files/01 Instance and Devices/14 Selecting index of a queue family with desired capabilities.cpp
+++ b/Library/Source Files/01 Instance and Devices/14 Selecting index of a queue family with desired capabilities.cpp
@@ -41,7 +41,7 @@ namespace VulkanCookbook {
 
     for( uint32_t index = 0; index < static_cast<uint32_t>(queue_families.size()); ++index ) {
       if( (queue_families[index].queueCount > 0) &&
-          (queue_families[index].queueFlags & desired_capabilities ) ) {
+          ((queue_families[index].queueFlags & desired_capabilities) == desired_capabilities) ) {
         queue_family_index = index;
         return true;
       }


### PR DESCRIPTION
Not sure if you accept PRs on this, but I noticed a minor bug while working through the book: the existing condition will evaluate to true if one or more of the desired flags is set on the queue, this change will ensure **all** desired flags are set. 

For example, if you ask for `VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT`, a queue with only one of those set would (incorrectly) pass the check.